### PR TITLE
Only attempt to unserialize the allowed types against a user group if it...

### DIFF
--- a/app/code/community/RicoNeitzel/PaymentFilter/Model/Observer.php
+++ b/app/code/community/RicoNeitzel/PaymentFilter/Model/Observer.php
@@ -66,8 +66,10 @@ class RicoNeitzel_PaymentFilter_Model_Observer extends Mage_Core_Model_Abstract
 
         $group = $observer->getEvent()->getObject();
 
-        $val = unserialize($group->getAllowedPaymentMethods());
-        $group->setAllowedPaymentMethods($val);
+        if (is_string($group->getAllowedPaymentMethods())) {
+            $val = unserialize($group->getAllowedPaymentMethods());
+            $group->setAllowedPaymentMethods($val);
+        }
     }
 
     /**


### PR DESCRIPTION
... is a string. This prevents an issue when using the API call shoppingCartPaymentList
