### PR TITLE
Try to make use of the event provided quote

### DIFF
--- a/app/code/community/RicoNeitzel/PaymentFilter/Model/Observer.php
+++ b/app/code/community/RicoNeitzel/PaymentFilter/Model/Observer.php
@@ -116,8 +116,9 @@ class RicoNeitzel_PaymentFilter_Model_Observer extends Mage_Core_Model_Abstract
     }
 
     /**
-     * Initialize the payment methods attribute value wth an array if it is empty.
-     * If we dont do this we cannot deselect all payment methods for a product.
+     * Initialize the payment methods attribute value with an array if it is
+     * empty.
+     * If we don' do this we cannot deselect all payment methods for a product.
      *
      * @param Varien_Event_Observer $observer
      */
@@ -149,12 +150,13 @@ class RicoNeitzel_PaymentFilter_Model_Observer extends Mage_Core_Model_Abstract
 
         $checkResult = $observer->getEvent()->getResult();
         $method = $observer->getEvent()->getMethodInstance();
+        $quote = $observer->getEvent()->getQuote();
 
         /*
          * Check if the method is forbidden by products in the cart
          */
         if ($checkResult->isAvailable) {
-            if (in_array($method->getCode(), Mage::helper('payfilter')->getForbiddenPaymentMethodsForCart())) {
+            if (in_array($method->getCode(), Mage::helper('payfilter')->getForbiddenPaymentMethodsForCart($quote))) {
                 $checkResult->isAvailable = false;
             }
         }


### PR DESCRIPTION
See issue #19 for details on the root cause.

Implementation details:
- Add a getCurrentQuote in same style as customer group but log a
  NOTICE-level message if we use it.
- For interfaces that need it, add an optional quote argument
- In the observer, get the quote from the event and pass it on to
  methods that need it.

Note:
- Quote is cached on the helper, but not verified to be the same quote
  within one request. I've cut it from this patch (is in orignal fix) as
  I can't come up with valid real-world corner cases.
- I've set the forceLog flag to true, as it is of interest for anyone
  interested in the system log, however, this should probably be turned
  off.
