### PR TITLE
Fixed "Loading quote from session" log message

### DIFF
--- a/app/code/community/RicoNeitzel/PaymentFilter/Helper/Payment/Data.php
+++ b/app/code/community/RicoNeitzel/PaymentFilter/Helper/Payment/Data.php
@@ -44,7 +44,7 @@ class RicoNeitzel_PaymentFilter_Helper_Payment_Data extends Mage_Payment_Helper_
                 if (
                     in_array(
                         $method->getCode(),
-                        Mage::helper('payfilter')->getForbiddenPaymentMethodsForCart())
+                        Mage::helper('payfilter')->getForbiddenPaymentMethodsForCart($quote))
                 ) {
                     continue;
                 }


### PR DESCRIPTION
Because the quote was not transmitted to getForbiddenPaymentMethodsForCart() method here, it was taken from session in helper RicoNeitzel_PaymentFilter_Helper_Data. This triggered the log message "Loading quote from session".